### PR TITLE
chore: wait for container port before serving

### DIFF
--- a/cloudflare/src/index.js
+++ b/cloudflare/src/index.js
@@ -7,7 +7,8 @@ export class SearxNGContainer extends Container {
 export default {
   async fetch(request, env) {
     const id = env.SEARXNG_CONTAINER.idFromName("default");
-    const container = env.SEARXNG_CONTAINER.get(id);
-    return container.fetch(request);
+    const stub = env.SEARXNG_CONTAINER.get(id);
+    await stub.startAndWaitForPorts([8080]);
+    return await stub.fetch(request);
   },
 };


### PR DESCRIPTION
## Summary
- ensure Cloudflare Worker waits for container to listen on port 8080 before forwarding requests

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68922602708c8328baf797e88d094710