### PR TITLE
Ensure Cloudflare container starts before handling requests

### DIFF
--- a/cloudflare/src/index.js
+++ b/cloudflare/src/index.js
@@ -2,13 +2,15 @@ import { Container } from "@cloudflare/containers";
 
 export class SearxNGContainer extends Container {
   defaultPort = 8080;
+  // keep the container alive for 10 minutes after the last request
+  sleepAfter = "10m";
 }
 
 export default {
   async fetch(request, env) {
     const id = env.SEARXNG_CONTAINER.idFromName("default");
-    const stub = env.SEARXNG_CONTAINER.get(id);
-    await stub.startAndWaitForPorts([8080]);
-    return await stub.fetch(request);
+    const container = env.SEARXNG_CONTAINER.get(id);
+    await container.startAndWaitForPorts([8080]);
+    return await container.fetch(request);
   },
 };


### PR DESCRIPTION
## Summary
- start the Cloudflare SearxNG container before proxying requests
- keep the container warm for 10 minutes after the last request

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6892295cb1d8832882b7e744174aa33f