### PR TITLE
feat(cloudflare): build SearXNG image locally

### DIFF
--- a/cloudflare/.dockerignore
+++ b/cloudflare/.dockerignore
@@ -1,0 +1,2 @@
+*
+!settings.yml

--- a/cloudflare/Dockerfile
+++ b/cloudflare/Dockerfile
@@ -1,0 +1,9 @@
+FROM docker.io/searxng/searxng:latest
+
+# Optionally copy a custom settings.yml if present
+# Only settings.yml is sent in build context via .dockerignore
+COPY . /tmp/context
+RUN if [ -f /tmp/context/settings.yml ]; then \
+        mv /tmp/context/settings.yml /etc/searxng/settings.yml && \
+        chown searxng:searxng /etc/searxng/settings.yml; \
+    fi && rm -rf /tmp/context

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -1,0 +1,13 @@
+# Cloudflare Container Deployment
+
+This directory contains the configuration needed to deploy [SearXNG](https://github.com/searxng/searxng) on Cloudflare's container platform.
+
+## Deployment
+
+To deploy the container:
+
+```bash
+npx wrangler deploy
+```
+
+Wrangler builds the local Dockerfile, pushes the resulting image to Cloudflare's registry, and deploys the container automatically. No manual Docker build or push is required.

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -5,10 +5,9 @@ compatibility_flags = ["nodejs_compat"]
 
 [[containers]]
 name = "searxng"
-class_name = "SearxNGContainer"
-image = "ghcr.io/searxng/searxng:latest"
+image = "./Dockerfile"
 instance_type = "basic"
-autoscaling = { minimum_instances = 1, cpu_target = 0.6 }
+max_instances = 1
 env = { FORCE_OWNERSHIP = "false", CONFIG_PATH = "/tmp/config", DATA_PATH = "/tmp/data" }
 
 [[durable_objects.bindings]]


### PR DESCRIPTION
## Summary
- build SearXNG container from a local Dockerfile
- configure Cloudflare deployment to use local image
- document container deployment workflow

## Testing
- `pytest tests/unit/test_exceptions.py`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689231979bd08328ab1098cb8892ba5d