### PR TITLE
Use prebuilt SearxNG image for Cloudflare

### DIFF
--- a/cloudflare/Dockerfile
+++ b/cloudflare/Dockerfile
@@ -1,9 +1,0 @@
-FROM docker.io/searxng/searxng:latest
-
-# Optionally copy a custom settings.yml if present
-# Only settings.yml is sent in build context via .dockerignore
-COPY . /tmp/context
-RUN if [ -f /tmp/context/settings.yml ]; then \
-        mv /tmp/context/settings.yml /etc/searxng/settings.yml && \
-        chown searxng:searxng /etc/searxng/settings.yml; \
-    fi && rm -rf /tmp/context

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -10,4 +10,4 @@ To deploy the container:
 npx wrangler deploy
 ```
 
-Wrangler builds the local Dockerfile, pushes the resulting image to Cloudflare's registry, and deploys the container automatically. No manual Docker build or push is required.
+Wrangler pulls the official `ghcr.io/searxng/searxng` image and deploys it directly to Cloudflare. No local Docker build or push is required.

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -5,7 +5,7 @@ compatibility_flags = ["nodejs_compat"]
 
 [[containers]]
 name = "searxng"
-image = "./Dockerfile"
+image = "ghcr.io/searxng/searxng"
 instance_type = "basic"
 max_instances = 1
 env = { FORCE_OWNERSHIP = "false", CONFIG_PATH = "/tmp/config", DATA_PATH = "/tmp/data" }


### PR DESCRIPTION
## Summary
- Deploy with the official `ghcr.io/searxng/searxng` image instead of building a local container.
- Clarify Cloudflare deployment docs to note the remote image pull.

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_68923e804c408328b8c52f894de46455